### PR TITLE
feat: update card data with range, evolution, and stat values

### DIFF
--- a/cards.json
+++ b/cards.json
@@ -1798,7 +1798,7 @@
         {
             "name": "Sparky",
             "id": 26000033,
-            "elixirCost": 5,
+            "elixirCost": 6,
             "targets": [
                 "ground"
             ],
@@ -2452,7 +2452,7 @@
         {
             "name": "Executioner",
             "id": 26000045,
-            "elixirCost": 6,
+            "elixirCost": 5,
             "targets": [
                 "air",
                 "ground"
@@ -4684,7 +4684,7 @@
         {
             "name": "Goblin Hut",
             "id": 27000001,
-            "elixirCost": 5,
+            "elixirCost": 4,
             "targets": [
                 "ground",
                 "air"
@@ -5064,7 +5064,7 @@
         {
             "name": "X-Bow",
             "id": 27000008,
-            "elixirCost": 5,
+            "elixirCost": 6,
             "targets": [
                 "ground",
                 "buildings"

--- a/cards.json
+++ b/cards.json
@@ -49,7 +49,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "common",
             "type": "troop"
@@ -158,7 +158,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "very-fast",
-            "range": null,
+            "range": 0.5,
             "territory": "restricted",
             "rarity": "common",
             "type": "troop"
@@ -212,7 +212,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "slow",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "rare",
             "type": "troop"
@@ -266,7 +266,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "slow",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "epic",
             "type": "troop"
@@ -320,7 +320,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "fast",
-            "range": null,
+            "range": 2.5,
             "territory": "restricted",
             "rarity": "common",
             "type": "troop"
@@ -374,7 +374,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 0.1,
             "territory": "restricted",
             "rarity": "epic",
             "type": "troop"
@@ -483,7 +483,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 0.7,
             "territory": "restricted",
             "rarity": "common",
             "type": "troop"
@@ -537,7 +537,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "slow",
-            "range": null,
+            "range": 0.75,
             "territory": "restricted",
             "rarity": "epic",
             "type": "troop"
@@ -591,7 +591,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "very-fast",
-            "range": null,
+            "range": 0.5,
             "territory": "restricted",
             "rarity": "common",
             "type": "troop"
@@ -645,7 +645,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "rare",
             "type": "troop"
@@ -699,7 +699,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "very-fast",
-            "range": null,
+            "range": 0.5,
             "territory": "restricted",
             "rarity": "epic",
             "type": "troop"
@@ -917,7 +917,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 1.6,
             "territory": "restricted",
             "rarity": "epic",
             "type": "troop"
@@ -1026,7 +1026,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "fast",
-            "range": null,
+            "range": 0.8,
             "territory": "restricted",
             "rarity": "rare",
             "type": "troop"
@@ -1081,7 +1081,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "very-fast",
-            "range": 5.5,
+            "range": 5.0,
             "territory": "restricted",
             "rarity": "common",
             "type": "troop"
@@ -1135,7 +1135,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "slow",
-            "range": null,
+            "range": 0.8,
             "territory": "restricted",
             "rarity": "epic",
             "type": "troop"
@@ -1189,7 +1189,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "very-fast",
-            "range": null,
+            "range": 0.8,
             "territory": "restricted",
             "rarity": "rare",
             "type": "troop"
@@ -1407,7 +1407,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "fast",
-            "range": null,
+            "range": 1.6,
             "territory": "restricted",
             "rarity": "epic",
             "type": "troop"
@@ -1516,7 +1516,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "epic",
             "type": "troop"
@@ -1735,7 +1735,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "very-fast",
-            "range": 2.0,
+            "range": 2.5,
             "territory": "restricted",
             "rarity": "common",
             "type": "troop"
@@ -1790,7 +1790,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "fast",
-            "range": null,
+            "range": 1.2,
             "territory": "wide",
             "rarity": "legendary",
             "type": "troop"
@@ -1952,7 +1952,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "very-fast",
-            "range": null,
+            "range": 0.7,
             "territory": "restricted",
             "rarity": "legendary",
             "type": "troop"
@@ -2006,7 +2006,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 0.5,
             "territory": "restricted",
             "rarity": "rare",
             "type": "troop"
@@ -2115,7 +2115,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "slow",
-            "range": null,
+            "range": 0.75,
             "territory": "restricted",
             "rarity": "rare",
             "type": "troop"
@@ -2170,7 +2170,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 1.6,
             "territory": "restricted",
             "rarity": "rare",
             "type": "troop"
@@ -2280,7 +2280,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "very-fast",
-            "range": null,
+            "range": 0.5,
             "territory": "restricted",
             "rarity": "common",
             "type": "troop"
@@ -2389,7 +2389,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "very-fast",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "common",
             "type": "troop"
@@ -2553,7 +2553,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "very-fast",
-            "range": null,
+            "range": 0.75,
             "territory": "restricted",
             "rarity": "legendary",
             "type": "troop"
@@ -2607,7 +2607,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 1.6,
             "territory": "restricted",
             "rarity": "common",
             "type": "troop"
@@ -2661,7 +2661,7 @@
             "generationSpeed": 5.0,
             "generationUnits": 2,
             "speed": "fast",
-            "range": null,
+            "range": 1.6,
             "territory": "restricted",
             "rarity": "legendary",
             "type": "troop"
@@ -2716,7 +2716,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "very-fast",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "common",
             "type": "troop"
@@ -2770,7 +2770,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "fast",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "legendary",
             "type": "troop"
@@ -2826,7 +2826,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 0.8,
             "territory": "restricted",
             "rarity": "legendary",
             "type": "troop"
@@ -2936,7 +2936,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 0.8,
             "territory": "restricted",
             "rarity": "common",
             "type": "troop"
@@ -3044,7 +3044,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "legendary",
             "type": "troop"
@@ -3207,7 +3207,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "very-fast",
-            "range": null,
+            "range": 0.5,
             "territory": "restricted",
             "rarity": "epic",
             "type": "troop"
@@ -3261,7 +3261,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "fast",
-            "range": null,
+            "range": 0.75,
             "territory": "restricted",
             "rarity": "rare",
             "type": "troop"
@@ -3315,7 +3315,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "fast",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "epic",
             "type": "troop"
@@ -3369,7 +3369,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "legendary",
             "type": "troop"
@@ -3588,7 +3588,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 1.6,
             "territory": "restricted",
             "rarity": "champion",
             "type": "troop"
@@ -3642,7 +3642,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "slow",
-            "range": null,
+            "range": 0.8,
             "territory": "restricted",
             "rarity": "rare",
             "type": "troop"
@@ -3696,7 +3696,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 1.6,
             "territory": "restricted",
             "rarity": "rare",
             "type": "troop"
@@ -3750,7 +3750,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "champion",
             "type": "troop"
@@ -3859,7 +3859,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "champion",
             "type": "troop"
@@ -3913,7 +3913,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "champion",
             "type": "troop"
@@ -4132,7 +4132,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "slow",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "epic",
             "type": "troop"
@@ -4187,7 +4187,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "very-fast",
-            "range": null,
+            "range": 1.6,
             "territory": "restricted",
             "rarity": "legendary",
             "type": "troop"
@@ -4242,7 +4242,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": 6.0,
+            "range": 5.5,
             "territory": "restricted",
             "rarity": "champion",
             "type": "troop"
@@ -4350,7 +4350,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": 5.0,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "legendary",
             "type": "troop"
@@ -4460,7 +4460,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": 5.5,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "champion",
             "type": "troop"
@@ -4514,7 +4514,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
-            "range": null,
+            "range": 1.2,
             "territory": "restricted",
             "rarity": "epic",
             "type": "troop"
@@ -4622,7 +4622,7 @@
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "fast",
-            "range": null,
+            "range": 0.8,
             "territory": "restricted",
             "rarity": "champion",
             "type": "troop"

--- a/cards.json
+++ b/cards.json
@@ -1295,7 +1295,7 @@
                 }
             },
             "hitspeed": 1.7,
-            "radius": null,
+            "radius": 3.0,
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
@@ -2331,7 +2331,7 @@
                 }
             },
             "hitspeed": 1.8,
-            "radius": null,
+            "radius": 3.0,
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",
@@ -3692,7 +3692,7 @@
                 }
             },
             "hitspeed": 1.5,
-            "radius": null,
+            "radius": 2.5,
             "generationSpeed": null,
             "generationUnits": null,
             "speed": "medium",

--- a/cards.json
+++ b/cards.json
@@ -2001,7 +2001,7 @@
                     "level15": 1409
                 }
             },
-            "hitspeed": 1.3,
+            "hitspeed": 0.4,
             "radius": null,
             "generationSpeed": null,
             "generationUnits": null,
@@ -2494,7 +2494,7 @@
                     "level15": 1864
                 }
             },
-            "hitspeed": 2.4,
+            "hitspeed": 0.9,
             "radius": null,
             "generationSpeed": null,
             "generationUnits": null,
@@ -3093,7 +3093,7 @@
                     "level15": 967
                 }
             },
-            "hitspeed": 1.0,
+            "hitspeed": 0.3,
             "radius": null,
             "generationSpeed": null,
             "generationUnits": null,
@@ -4399,7 +4399,7 @@
                     "level15": null
                 }
             },
-            "hitspeed": 1.1,
+            "hitspeed": 0.3,
             "radius": null,
             "generationSpeed": null,
             "generationUnits": null,
@@ -4726,7 +4726,7 @@
                     "level15": null
                 }
             },
-            "hitspeed": 1.7,
+            "hitspeed": 10.0,
             "radius": null,
             "generationSpeed": 11.0,
             "generationUnits": 3,
@@ -4944,7 +4944,7 @@
                     "level15": null
                 }
             },
-            "hitspeed": 1.3,
+            "hitspeed": 10.0,
             "radius": null,
             "generationSpeed": 15.0,
             "generationUnits": 3,
@@ -5160,7 +5160,7 @@
                     "level15": null
                 }
             },
-            "hitspeed": 1.0,
+            "hitspeed": 10.0,
             "radius": null,
             "generationSpeed": 4.0,
             "generationUnits": 2,
@@ -5269,7 +5269,7 @@
                     "level15": 1081
                 }
             },
-            "hitspeed": 1.4,
+            "hitspeed": 10.0,
             "radius": null,
             "generationSpeed": null,
             "generationUnits": null,
@@ -5324,7 +5324,7 @@
                     "level15": 2330
                 }
             },
-            "hitspeed": 1.1,
+            "hitspeed": 1.2,
             "radius": null,
             "generationSpeed": null,
             "generationUnits": null,
@@ -6253,7 +6253,7 @@
                     "level15": null
                 }
             },
-            "hitspeed": 1.0,
+            "hitspeed": 0.3,
             "radius": null,
             "generationSpeed": null,
             "generationUnits": null,

--- a/cards.json
+++ b/cards.json
@@ -2227,7 +2227,7 @@
             "speed": "very-fast",
             "range": 6.5,
             "territory": "restricted",
-            "rarity": "common",
+            "rarity": "rare",
             "type": "troop"
         },
         {
@@ -5167,7 +5167,7 @@
             "speed": null,
             "range": 2.0,
             "territory": "restricted",
-            "rarity": "common",
+            "rarity": "rare",
             "type": "building"
         },
         {
@@ -5713,7 +5713,7 @@
             "speed": null,
             "range": null,
             "territory": "restricted",
-            "rarity": "rare",
+            "rarity": "epic",
             "type": "spell"
         },
         {

--- a/cards.json
+++ b/cards.json
@@ -823,7 +823,7 @@
             ],
             "units": 1,
             "duration": null,
-            "evolution": false,
+            "evolution": true,
             "typeAttack": "splash",
             "projectile": true,
             "suicide": false,
@@ -848,14 +848,14 @@
                 "level15": 1674
             },
             "statsEvo": {
-                "cycles": null,
+                "cycles": 1,
                 "damage": {
-                    "level11": null,
-                    "level15": null
+                    "level11": 161,
+                    "level15": 234
                 },
                 "hitpoints": {
-                    "level11": null,
-                    "level15": null
+                    "level11": 1152,
+                    "level15": 1674
                 }
             },
             "hitspeed": 1.5,

--- a/cards.json
+++ b/cards.json
@@ -6537,6 +6537,61 @@
             "territory": "restricted",
             "rarity": "legendary",
             "type": "troop"
+        },
+        {
+            "name": "Vines",
+            "id": 28000026,
+            "elixirCost": 3,
+            "targets": [
+                "ground",
+                "air"
+            ],
+            "units": 0,
+            "duration": 2.5,
+            "evolution": false,
+            "typeAttack": "splash",
+            "projectile": false,
+            "suicide": false,
+            "fatalDamage": {
+                "level11": null,
+                "level15": null
+            },
+            "chargeDamage": {
+                "level11": null,
+                "level15": null
+            },
+            "towerDamage": {
+                "level11": null,
+                "level15": null
+            },
+            "damage": {
+                "level11": null,
+                "level15": null
+            },
+            "hitpoints": {
+                "level11": null,
+                "level15": null
+            },
+            "statsEvo": {
+                "cycles": null,
+                "damage": {
+                    "level11": null,
+                    "level15": null
+                },
+                "hitpoints": {
+                    "level11": null,
+                    "level15": null
+                }
+            },
+            "hitspeed": null,
+            "radius": 2.5,
+            "generationSpeed": null,
+            "generationUnits": null,
+            "speed": null,
+            "range": null,
+            "territory": "wide",
+            "rarity": "epic",
+            "type": "spell"
         }
     ],
     "towerCards": [

--- a/cards.json
+++ b/cards.json
@@ -1968,7 +1968,7 @@
             "duration": null,
             "evolution": true,
             "typeAttack": "unique",
-            "projectile": true,
+            "projectile": false,
             "suicide": false,
             "fatalDamage": {
                 "level11": null,
@@ -4476,7 +4476,7 @@
             "duration": null,
             "evolution": false,
             "typeAttack": "unique",
-            "projectile": true,
+            "projectile": false,
             "suicide": false,
             "fatalDamage": {
                 "level11": null,


### PR DESCRIPTION
This PR updates the card data in cards.json with several important changes:

### Changes Made:
- **Range values**: Added range values for multiple troop cards that previously had null values
- **Evolution data**: Added evolution and statsEvo values for Baby Dragon card
- **Projectile properties**: Fixed projectile property from true to false for specific cards
- **Rarity updates**: Updated rarity for several cards (common → rare, rare → epic, etc.)
- **Stat values**: Added radius values for multiple cards
- **Hit speed updates**: Updated hitspeed values for various cards
- **Elixir cost fixes**: Corrected elixir costs for several cards (Goblin Hut: 5→4, X-Bow: 5→6, Executioner: 6→5, Sparky: 5→6)
- **New card**: Added new Vines card (Epic spell, 3 elixir, 2.5s duration)

### Cards Affected:
- Multiple troop cards received range values (0.5, 0.7, 0.75, 0.8, 1.2, 1.6, 2.5, etc.)
- Baby Dragon now has evolution data with proper stats
- Several cards had projectile property corrected
- Various cards had rarity, radius, hitspeed, and elixir cost updates
- New Vines spell card added to the collection

These updates improve the accuracy and completeness of the card data for better game balance and functionality.